### PR TITLE
Improve tooltip performance with sorting cache

### DIFF
--- a/Core/GUI/DataBrokerDisplay.lua
+++ b/Core/GUI/DataBrokerDisplay.lua
@@ -79,7 +79,8 @@ function dataobj:OnClick(button)
 end
 
 function GUI:UpdateText()
-	dataobj = self.dataobj
+       self:InvalidateSortCache()
+       dataobj = self.dataobj
 
 	self = Rarity
 


### PR DESCRIPTION
## Summary
- cache sorting results for tooltip groups
- reset cache when updated text or sort order changes

## Testing
- `luacheck Core/GUI/MainWindow.lua Core/GUI/DataBrokerDisplay.lua`
- `./evo Tests/unit-test.lua` *(fails: C_Timer nil)*

------
https://chatgpt.com/codex/tasks/task_e_68868b291c2883269d65b3809c609e9c