### PR TITLE
Fix Yogg-Saron kill detection for Mimiron's Head

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -307,7 +307,7 @@ local encounterLUT = {
 	[1133] = { "Blessed Seed" }, -- Freya
 	[1135] = { "Ominous Pile of Snow" }, -- Hodir
 	[1138] = { "Overcomplicated Controller" }, -- Mimiron
-	[1143] = { "Wriggling Darkness" }, -- Yogg-Saron (mount uses the BOSS method and is tracked separately)
+	[1143] = { "Wriggling Darkness", "Mimiron's Head" }, -- Yogg-Saron (loot from Titan's Cache)
 	[1500] = { "Celestial Gift" }, -- Elegon
 	[1505] = { "Azure Cloud Serpent Egg" }, -- Tsulong
 	[1506] = { "Spirit of the Spring" }, -- Lei Shi
@@ -1024,9 +1024,9 @@ function R:ProcessContainerItems()
 									then
 										local isHordePlayer = R.Caching:IsHorde()
 										local canPlayerObtainFactionSpecificItem = not (
-												(vv.requiresHorde and not isHordePlayer)
-												or (vv.requiresAlliance and isHordePlayer)
-											)
+											(vv.requiresHorde and not isHordePlayer)
+											or (vv.requiresAlliance and isHordePlayer)
+										)
 										if canPlayerObtainFactionSpecificItem then
 											for kkk, vvv in pairs(vv.items) do
 												if vvv == k then

--- a/DB/Mounts/WrathOfTheLichKing.lua
+++ b/DB/Mounts/WrathOfTheLichKing.lua
@@ -39,7 +39,8 @@ local wotlkMounts = {
 		chance = 100,
 		instanceDifficulties = {
 			[CONSTANTS.INSTANCE_DIFFICULTIES.RAID_10_NORMAL] = true,
-			[CONSTANTS.INSTANCE_DIFFICULTIES.RAID_25_NORMAL] = true
+			[CONSTANTS.INSTANCE_DIFFICULTIES.RAID_25_NORMAL] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true,
 		},
 		sourceText = L["Dropped by Yogg-Saron in Ulduar with no Keepers assisting"],
 		wasGuaranteed = true,


### PR DESCRIPTION
## Summary
- fix detection for Mimiron's Head so kills count in modern Normal raids
- handle Yogg-Saron encounter end to add attempts

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68868f76690c83268fc34ce3293e39a7