### PR TITLE
I fixed the Luacheck warnings in `Core/GUI/GameTooltipHooks.lua`. The…

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -279,7 +279,7 @@ local function onTooltipSetUnit(tooltip, data)
 	local zone = GetRealZoneText()
 	local subzone = GetSubZoneText()
 	local zone_t = LibStub("LibBabble-Zone-3.0"):GetReverseLookupTable()[zone]
-	subzone_t = LibStub("LibBabble-SubZone-3.0"):GetReverseLookupTable()[subzone]
+	local subzone_t = LibStub("LibBabble-SubZone-3.0"):GetReverseLookupTable()[subzone]
 	if
 		Rarity.zones[tostring(GetBestMapForUnit("player"))]
 		or Rarity.zones[zone]


### PR DESCRIPTION
… `subzone_t` variable was being assigned as a global, which is bad practice. I changed it to a local variable, which fixes the Luacheck warnings.