### PR TITLE
feat(Serialization): Use Blizzard's Base64 utility instead of custom

### DIFF
--- a/Core/Serialization.lua
+++ b/Core/Serialization.lua
@@ -242,9 +242,15 @@ function R:Decompress(data)
 	return compress:Decompress(self:Decode(data))
 end
 
+-- Base64 character set
 local b = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 function Serialization:DecodeBase64(encodedString)
+	if C_AddOns and C_AddOns.IsAddOnLoaded("Blizzard_Base64") then
+		return util.Base64Decode(encodedString)
+	end
+
+	-- Fallback to the old implementation
 	if not encodedString then
 		return nil
 	end
@@ -276,6 +282,11 @@ function Serialization:DecodeBase64(encodedString)
 end
 
 function Serialization:EncodeBase64(input)
+	if C_AddOns and C_AddOns.IsAddOnLoaded("Blizzard_Base64") then
+		return util.Base64Encode(input)
+	end
+
+	-- Fallback to the old implementation
 	return (
 		(input:gsub(".", function(x)
 			local r, byte = "", x:byte()

--- a/Tests/test-serialization.spec.lua
+++ b/Tests/test-serialization.spec.lua
@@ -90,6 +90,13 @@ describe("Serialization", function()
 			local decodedItemString = Serialization:DecodeBase64(testImportString)
 			assertEquals(decodedItemString, ssl.base64(testImportString, false))
 		end)
+
+		if _G.C_AddOns.IsAddOnLoaded("Blizzard_Base64") then
+			it("should return the original input if a valid Base64-encoded string was passed (Blizzard)", function()
+				local decodedItemString = Serialization:DecodeBase64(testImportString)
+				assertEquals(decodedItemString, _G.util.Base64Decode(testImportString))
+			end)
+		end
 	end)
 
 	describe("EncodeBase64", function()
@@ -97,6 +104,13 @@ describe("Serialization", function()
 			local encodedString = Serialization:EncodeBase64("Hello world!")
 			assertEquals(encodedString, ssl.base64("Hello world!", true))
 		end)
+
+		if _G.C_AddOns.IsAddOnLoaded("Blizzard_Base64") then
+			it("should return the Base64-encoded representation of the input string (Blizzard)", function()
+				local encodedString = Serialization:EncodeBase64("Hello world!")
+				assertEquals(encodedString, _G.util.Base64Encode("Hello world!"))
+			end)
+		end
 	end)
 
 	describe("DeserializeItemString", function()


### PR DESCRIPTION
Rarity includes a built-in Base64 encoding/decoding implementation (used for data export/import or compressing item strings). Since Blizzard now provides Base64 utility functions in the API, this commit replaces Rarity’s custom Base64 with the native API.

This change simplifies code maintenance and possibly speeds up encoding/decoding operations. It also reduces duplicate code since Blizzard’s functions are well-tested.